### PR TITLE
feat: optional type wrapper implementation

### DIFF
--- a/optional/optional.go
+++ b/optional/optional.go
@@ -1,0 +1,44 @@
+// Package optional provides an implementation for an optional type wrapper.
+package optional
+
+// Optional manages an optional contained value.
+type Optional[T any] struct {
+	ptr *T
+}
+
+// New initializes an optional containing the given value.
+func New[T any](v T) Optional[T] {
+	return Optional[T]{&v}
+}
+
+// NewEmpty initializes an optional containing no value.
+func NewEmpty[T any]() Optional[T] {
+	return Optional[T]{}
+}
+
+// HasValue returns true if the optional holds a value.
+func (o Optional[T]) HasValue() bool {
+	return o.ptr != nil
+}
+
+// Value returns the value held in the optional.
+func (o Optional[T]) Value() T {
+	if !o.HasValue() {
+		panic("Trying to retrieve value from an empty optional")
+	}
+	return *o.ptr
+}
+
+// Set sets the value held in the optional.
+func (o *Optional[T]) Set(v T) {
+	o.ptr = &v
+}
+
+// ValueOr returns the value held in the optional if available, defaultValue
+// otherwise.
+func (o Optional[T]) ValueOr(defaultValue T) T {
+	if !o.HasValue() {
+		return defaultValue
+	}
+	return *o.ptr
+}

--- a/optional/optional_test.go
+++ b/optional/optional_test.go
@@ -1,0 +1,44 @@
+package optional
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestEmptyOptional(t *testing.T) {
+	opt := NewEmpty[int]()
+	assert.False(t, opt.HasValue())
+}
+
+func TestOptionalWithValue(t *testing.T) {
+	opt := New(42)
+	assert.True(t, opt.HasValue())
+}
+
+func TestOptionalValue(t *testing.T) {
+	opt := New(42)
+	assert.Equal(t, opt.Value(), 42)
+}
+
+func TestEmptyOptionalValue(t *testing.T) {
+	opt := NewEmpty[int]()
+	assert.Panics(t, func() { opt.Value() })
+}
+
+func TestOptionalValueOr(t *testing.T) {
+	opt := New(42)
+	assert.Equal(t, opt.ValueOr(1337), 42)
+}
+
+func TestEmptyOptionalValueOr(t *testing.T) {
+	opt := NewEmpty[int]()
+	assert.Equal(t, opt.ValueOr(1337), 1337)
+}
+
+func TestInlineOptionalMethodCall(t *testing.T) {
+	// If Optional methods have a pointer receiver, they can't be called on a
+	// non-addressable value (such as the direct return of New or NewEmpty)
+	assert.True(t, New(42).HasValue())
+	assert.Equal(t, New(42).Value(), 42)
+	assert.Equal(t, NewEmpty[int]().ValueOr(1337), 1337)
+}


### PR DESCRIPTION
For clarity reasons (avoiding raw pointers usage), I needed an optional type wrapper implementation.
What do you guys think? Are you opposed to it being used? Or do you see anything you would like changed?
Thanks for your feedback!

Examples can be found in the test files, as well as in PR #4